### PR TITLE
Add DaisyUI Nord theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@plugin "daisyui";
 
 :root {
   --background: #ffffff;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,8 +23,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+    <html lang="en" data-theme="nord">
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
+        {children}
+      </body>
     </html>
   );
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  plugins: [require('daisyui')],
+  daisyui: {
+    themes: ['nord'],
+  },
+};
+export default config;


### PR DESCRIPTION
## Summary
- configure Tailwind with DaisyUI Nord theme
- remove CSS plugin directive
- set `data-theme="nord"` in the layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e61b5d2f88320871730d251ced6a0