### PR TITLE
Add FlipCard component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,10 @@
+import FlipCard from "@/components/FlipCard/FlipCard";
+
 export default function Home() {
   return (
-    <div>
+    <div className="flex flex-col items-center gap-4">
       <h1>Welcome to Josh Site</h1>
+      <FlipCard />
     </div>
   );
 }

--- a/components/FlipCard/FlipCard.tsx
+++ b/components/FlipCard/FlipCard.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+export default function FlipCard() {
+  const [flipped, setFlipped] = useState(false);
+
+  return (
+    <div className="w-64 h-40 [perspective:1000px]">
+      <div
+        className="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d]"
+        style={{ transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)" }}
+      >
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-box bg-base-200 [backface-visibility:hidden]">
+          <span>Front</span>
+          <button className="btn btn-primary" onClick={() => setFlipped(true)}>
+            Flip to Back
+          </button>
+        </div>
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-box bg-base-200 [backface-visibility:hidden]"
+          style={{ transform: "rotateY(180deg)" }}
+        >
+          <span>Back</span>
+          <button className="btn btn-secondary" onClick={() => setFlipped(false)}>
+            Flip to Front
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `FlipCard` component for front/back flipping interaction
- show `FlipCard` on `Home` page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ea03e8cc48320b93e35627d6ef4bd