### PR TITLE
Update FlipCard design with tap hint

### DIFF
--- a/components/FlipCard/FlipCard.tsx
+++ b/components/FlipCard/FlipCard.tsx
@@ -10,12 +10,36 @@ export default function FlipCard() {
         className="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d]"
         style={{ transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)" }}
       >
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-box bg-base-200 [backface-visibility:hidden]">
-          <span>Front</span>
-          <button className="btn btn-primary" onClick={() => setFlipped(true)}>
-            Flip to Back
-          </button>
+        {/* Front Side */}
+        <div
+          className="absolute inset-0 flex items-center justify-center rounded-box bg-base-200 [backface-visibility:hidden] cursor-pointer"
+          onClick={() => setFlipped(true)}
+        >
+          {/* User Avatar Icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            className="h-16 w-16"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25v-.75A4.5 4.5 0 019 15h6a4.5 4.5 0 014.5 4.5v.75"
+            />
+          </svg>
+          {/* Tap hint */}
+          <div className="absolute bottom-2 right-2 flex items-center gap-1 text-sm">
+            <span>Tap</span>
+            <span className="text-lg" role="img" aria-label="tap gesture">
+              👆
+            </span>
+          </div>
         </div>
+
+        {/* Back Side */}
         <div
           className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-box bg-base-200 [backface-visibility:hidden]"
           style={{ transform: "rotateY(180deg)" }}


### PR DESCRIPTION
## Summary
- improve FlipCard UI
  - front shows a user avatar SVG
  - bottom-right tap hint with pointer emoji
  - clicking anywhere on front flips card

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683eae50dbf48320aa6f4c45687b3407