### PR TITLE
Add content tabs and integrate flip card

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,15 @@
+"use client";
+import { useState } from "react";
 import FlipCard from "@/components/FlipCard/FlipCard";
+import Content from "@/components/Content/Content";
 
 export default function Home() {
+  const [tab, setTab] = useState<"about" | "projects" | "contact">("about");
+
   return (
     <div className="w-full h-screen flex flex-row items-center justify-center gap-4">
-      <FlipCard />
+      <FlipCard onSelect={setTab} />
+      <Content activeTab={tab} />
     </div>
   );
 }

--- a/components/Content/Content.tsx
+++ b/components/Content/Content.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+import fileIcon from "@/public/file.svg";
+import globeIcon from "@/public/globe.svg";
+import windowIcon from "@/public/window.svg";
+
+interface ContentProps {
+  activeTab: "about" | "projects" | "contact";
+}
+
+export default function Content({ activeTab }: ContentProps) {
+  return (
+    <div className="w-full md:w-96 h-80 md:h-200 rounded-box bg-base-200 p-4 flex items-center justify-center">
+      {activeTab === "about" && (
+        <div className="flex flex-col items-center gap-2">
+          <Image src={fileIcon} alt="about" width={32} height={32} />
+          <p className="text-center">Hello! I am Josh, a software engineer.</p>
+        </div>
+      )}
+      {activeTab === "projects" && (
+        <div className="flex flex-col items-center gap-2">
+          <Image src={windowIcon} alt="projects" width={32} height={32} />
+          <p className="text-center">Projects coming soon.</p>
+        </div>
+      )}
+      {activeTab === "contact" && (
+        <div className="flex flex-col items-center gap-2">
+          <Image src={globeIcon} alt="contact" width={32} height={32} />
+          <p className="text-center">Reach me at josh@example.com</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/FlipCard/FlipCard.tsx
+++ b/components/FlipCard/FlipCard.tsx
@@ -2,8 +2,14 @@
 import { useState } from "react";
 import Image from "next/image";
 import draw from "@/public/draw.jpg";
+import fileIcon from "@/public/file.svg";
+import globeIcon from "@/public/globe.svg";
+import windowIcon from "@/public/window.svg";
 
-export default function FlipCard() {
+interface FlipCardProps {
+  onSelect: (tab: "about" | "projects" | "contact") => void;
+}
+export default function FlipCard({ onSelect }: FlipCardProps) {
   const [flipped, setFlipped] = useState(false);
 
   return (
@@ -15,15 +21,19 @@ export default function FlipCard() {
       >
         {/* Front Side */}
         <div
-          className="absolute inset-0 flex items-center justify-center rounded-box bg-base-200 [backface-visibility:hidden] cursor-pointer"
+          className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-box bg-base-200 [backface-visibility:hidden] cursor-pointer"
           onClick={() => setFlipped(true)}
         >
           {/* User Avatar Icon */}
-
           <div className="avatar">
             <div className="w-24 rounded-full">
-              <Image src={draw} alt={"me-draw"} width={480} height={480} />
+              <Image src={draw} alt="me-draw" width={480} height={480} />
             </div>
+          </div>
+          {/* Contact info */}
+          <div className="flex flex-col items-center">
+            <span className="font-bold">SE-Josh</span>
+            <span className="text-sm">josh@example.com</span>
           </div>
           {/* Tap hint */}
           <div className="absolute bottom-2 right-2 flex items-center gap-1 text-sm">
@@ -36,14 +46,30 @@ export default function FlipCard() {
 
         {/* Back Side */}
         <div
-          className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-box bg-base-200 [backface-visibility:hidden]"
+          className="absolute inset-0 flex flex-col items-center justify-center gap-4 rounded-box bg-base-200 [backface-visibility:hidden]"
           style={{ transform: "rotateY(180deg)" }}
         >
-          <span>Back</span>
-          <button
-            className="btn btn-secondary"
-            onClick={() => setFlipped(false)}
-          >
+          <div className="flex gap-2">
+            <button
+              className="btn btn-sm btn-circle"
+              onClick={() => onSelect("about")}
+            >
+              <Image src={fileIcon} alt="about" width={24} height={24} />
+            </button>
+            <button
+              className="btn btn-sm btn-circle"
+              onClick={() => onSelect("projects")}
+            >
+              <Image src={windowIcon} alt="projects" width={24} height={24} />
+            </button>
+            <button
+              className="btn btn-sm btn-circle"
+              onClick={() => onSelect("contact")}
+            >
+              <Image src={globeIcon} alt="contact" width={24} height={24} />
+            </button>
+          </div>
+          <button className="btn btn-secondary" onClick={() => setFlipped(false)}>
             Flip to Front
           </button>
         </div>


### PR DESCRIPTION
## Summary
- build `Content` component to show content tabs
- update `FlipCard` with selectable buttons and contact info
- add state management in `Home` page to switch between tabs

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841480a85f883208c0b7588ce1269ae