### PR TITLE
Refine responsive layout with Tailwind

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,32 @@ import Content from "@/components/Content/Content";
 
 export default function Home() {
   const [tab, setTab] = useState<"about" | "projects" | "contact">("about");
+  const [open, setOpen] = useState(false);
+
+  // open modal on any tab selection; CSS handles visibility per breakpoint
+  const handleSelect = (nextTab: "about" | "projects" | "contact") => {
+    setTab(nextTab);
+    setOpen(true);
+  };
 
   return (
-    <div className="w-full h-screen flex flex-row items-center justify-center gap-4">
-      <FlipCard onSelect={setTab} />
-      <Content activeTab={tab} />
+    <div className="w-full h-screen flex flex-col items-center justify-center gap-4 md:flex-row">
+      <FlipCard onSelect={handleSelect} />
+      <div className="hidden md:block">
+        <Content activeTab={tab} />
+      </div>
+      {open && (
+        <dialog className="modal modal-open md:hidden">
+          <div className="modal-box">
+            <Content activeTab={tab} />
+            <div className="modal-action">
+              <button className="btn" onClick={() => setOpen(false)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </dialog>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- open modal unconditionally on tab select
- show modal only on mobile using `md:` utilities

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68414b1bac9c83208e3415ffe947864d