### PR TITLE
Refactor modal behavior to use dialog API

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,16 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import FlipCard from "@/components/FlipCard/FlipCard";
 import Content from "@/components/Content/Content";
 
 export default function Home() {
   const [tab, setTab] = useState<"about" | "projects" | "contact">("about");
-  const [open, setOpen] = useState(false);
+  const modalRef = useRef<HTMLDialogElement>(null);
 
   // open modal on any tab selection; CSS handles visibility per breakpoint
   const handleSelect = (nextTab: "about" | "projects" | "contact") => {
     setTab(nextTab);
-    setOpen(true);
+    modalRef.current?.showModal();
   };
 
   return (
@@ -19,18 +19,14 @@ export default function Home() {
       <div className="hidden md:block">
         <Content activeTab={tab} />
       </div>
-      {open && (
-        <dialog className="modal modal-open md:hidden">
-          <div className="modal-box">
-            <Content activeTab={tab} />
-            <div className="modal-action">
-              <button className="btn" onClick={() => setOpen(false)}>
-                Close
-              </button>
-            </div>
-          </div>
-        </dialog>
-      )}
+      <dialog ref={modalRef} id="tab_modal" className="modal md:hidden">
+        <div className="modal-box w-full h-full max-w-none">
+          <Content activeTab={tab} />
+        </div>
+        <form method="dialog" className="modal-backdrop p-5">
+          <button>close</button>
+        </form>
+      </dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- open and close modal using dialog `showModal()`
- make modal fullscreen and provide clickable backdrop

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68415415aef483208d104b5c0a49c418