### PR TITLE
Implement skills mockup

### DIFF
--- a/components/Content/Content.tsx
+++ b/components/Content/Content.tsx
@@ -3,6 +3,7 @@ import globeIcon from "@/public/globe.svg";
 import certGithub from "@/public/Cert-GitHub.jpg";
 import certAzure from "@/public/Cert-Azure.jpg";
 import certDocker from "@/public/Cert-Docker.jpg";
+import SkillsMockup from "@/components/SkillsMockup";
 import type { Tab } from "@/types";
 
 interface ContentProps {
@@ -228,7 +229,7 @@ export default function Content({ activeTab }: ContentProps) {
       )}
       {activeTab === "skills" && (
         <section className="flex items-center justify-center w-full h-full">
-          <p className="opacity-50">Skills section coming soon...</p>
+          <SkillsMockup />
         </section>
       )}
     </div>

--- a/components/SkillsMockup.tsx
+++ b/components/SkillsMockup.tsx
@@ -1,0 +1,25 @@
+import type { FC } from "react";
+
+const SkillsMockup: FC = () => {
+  return (
+    <div className="mockup-code bg-base-200">
+      <pre data-prefix="$">
+        <code>{`const skillSet = {`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-warning">
+        <code>{`  languages: ['TypeScript', 'Python']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-success">
+        <code>{`  frameworks: ['Next.js', 'React']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-info">
+        <code>{`  tools: ['Docker', 'GitHub']`}</code>
+      </pre>
+      <pre data-prefix="$">
+        <code>{`};`}</code>
+      </pre>
+    </div>
+  );
+};
+
+export default SkillsMockup;


### PR DESCRIPTION
## Summary
- add `SkillsMockup` component using daisyUI `mockup-code`
- import and display `SkillsMockup` in the `skills` tab of `Content`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843e4cb268c8320a3139a5e2397a0e0