### PR TITLE
Update skillset categories

### DIFF
--- a/components/SkillsMockup/SkillsMockup.tsx
+++ b/components/SkillsMockup/SkillsMockup.tsx
@@ -7,13 +7,28 @@ const SkillsMockup: FC = () => {
         <code>{`const skillSet = {`}</code>
       </pre>
       <pre data-prefix="&gt;" className="text-primary">
-        <code>{`  languages: ['TypeScript', 'Python']`}</code>
+        <code>{`  solutions: ['IoT', 'AI']`}</code>
       </pre>
       <pre data-prefix="&gt;" className="text-secondary">
-        <code>{`  frameworks: ['Next.js', 'React']`}</code>
+        <code>{`  messaging: ['MQTT', 'Kafka']`}</code>
       </pre>
       <pre data-prefix="&gt;" className="text-accent">
-        <code>{`  tools: ['Docker', 'GitHub']`}</code>
+        <code>{`  aiot: ['EdgeX', 'Azure IoT']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-info">
+        <code>{`  security: ['OAuth2', 'JWT']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-success">
+        <code>{`  cloud: ['AWS', 'Azure']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-warning">
+        <code>{`  documentation: ['Markdown', 'Swagger']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-info">
+        <code>{`  workflow: ['Jira', 'Trello']`}</code>
+      </pre>
+      <pre data-prefix="&gt;" className="text-success">
+        <code>{`  ciCd: ['GitHub Actions', 'GitLab CI']`}</code>
       </pre>
       <pre data-prefix="$">
         <code>{`};`}</code>


### PR DESCRIPTION
## Summary
- update SkillsMockup.tsx to display eight categories using color-coded lines

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843ef5298c88320b66d7a880e8ce6b2